### PR TITLE
Fix check script download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ npm list -g axios
 
 **Mac/Linux:**
 ```bash
-curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash
+curl -sL https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/refs/heads/main/check.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex
+irm https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/refs/heads/main/check.ps1 | iex
 ```
 
 Or clone and run locally:


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to use the correct GitHub username and branch reference for the script URLs.

- Documentation update:
  * Changed the script download URLs in the Mac/Linux and Windows installation instructions to use `theNetworkChuck` as the username and `refs/heads/main` as the branch reference, ensuring users fetch the scripts from the correct repository and branch.