### PR TITLE
Fix incorrect GitHub username in README URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ npm list -g axios
 
 **Mac/Linux:**
 ```bash
-curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash
+curl -sL https://raw.githubusercontent.com/thenetworkchuck/axios-attack-guide/main/check.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex
+irm https://raw.githubusercontent.com/thenetworkchuck/axios-attack-guide/main/check.ps1 | iex
 ```
 
 Or clone and run locally:
 ```bash
-git clone https://github.com/networkchuck/axios-attack-guide.git
+git clone https://github.com/thenetworkchuck/axios-attack-guide.git
 cd axios-attack-guide
 ./check.sh        # Mac/Linux
 .\check.ps1       # Windows PowerShell


### PR DESCRIPTION
## Summary
- Fixed 3 URLs in README.md that used `networkchuck` instead of the correct `theNetworkChuck` GitHub username
- This caused the raw.githubusercontent.com links for `check.sh` and `check.ps1` to point to incorrect locations
- Also fixed the `git clone` URL

## Changes
- Line 28: curl URL for check.sh
- Line 33: irm URL for check.ps1
- Line 38: git clone URL