### PR TITLE
feat: extend lockfile checks to yarn, pnpm, bun, and deno

### DIFF
--- a/check.ps1
+++ b/check.ps1
@@ -26,6 +26,7 @@ if ($axiosCheck) {
 Write-Host ""
 Write-Host "[2/5] Checking lockfile..." -ForegroundColor Yellow
 $lockfileFound = $false
+$pkgManager = "npm"  # default; overridden below if another lockfile is found
 
 # Helper: find compromised axios version in decoded yarn-style text
 function Find-AxiosInYarnFormat($lines) {
@@ -40,11 +41,13 @@ function Find-AxiosInYarnFormat($lines) {
 
 if (Test-Path "package-lock.json") {
     $lockfileFound = $true
+    $lockHit = $null  # reset to avoid carry-over from a previous check
     # Scope to the axios entry specifically, not any package with that version number
     $content = Get-Content "package-lock.json"
     $axiosIdx = ($content | Select-String -Pattern '"node_modules/axios"').LineNumber
     if ($axiosIdx) {
-        $block = $content[($axiosIdx)..([math]::Min($axiosIdx+3, $content.Count-1))]
+        # LineNumber is 1-based; subtract 1 for 0-based array index
+        $block = $content[($axiosIdx - 1)..([math]::Min($axiosIdx + 4, $content.Count - 1))]
         $lockHit = $block | Select-String -Pattern '"(1\.14\.1|0\.30\.4)"'
     }
     if ($lockHit) {
@@ -57,6 +60,7 @@ if (Test-Path "package-lock.json") {
 
 if (Test-Path "yarn.lock") {
     $lockfileFound = $true
+    $pkgManager = "yarn"
     $lockHit = Find-AxiosInYarnFormat (Get-Content "yarn.lock")
     if ($lockHit) {
         Write-Host "  !! AFFECTED: Compromised axios version found in yarn.lock" -ForegroundColor Red
@@ -68,6 +72,7 @@ if (Test-Path "yarn.lock") {
 
 if (Test-Path "pnpm-lock.yaml") {
     $lockfileFound = $true
+    $pkgManager = "pnpm"
     # pnpm entries are keyed as "/axios@VERSION:" or "axios@VERSION:"
     $lockHit = Select-String -Path "pnpm-lock.yaml" -Pattern "(^|/)axios@(1\.14\.1|0\.30\.4):"
     if ($lockHit) {
@@ -80,6 +85,7 @@ if (Test-Path "pnpm-lock.yaml") {
 
 if (Test-Path "deno.lock") {
     $lockfileFound = $true
+    $pkgManager = "deno"
     # deno.lock is JSON; npm entries are keyed as "axios@VERSION"
     $lockHit = Select-String -Path "deno.lock" -Pattern '"axios@(1\.14\.1|0\.30\.4)"'
     if ($lockHit) {
@@ -92,6 +98,7 @@ if (Test-Path "deno.lock") {
 
 if (Test-Path "bun.lockb") {
     $lockfileFound = $true
+    $pkgManager = "bun"
     $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
     if ($bunCmd) {
         # bun.lockb is binary — decode to yarn-style text first, then scope to axios blocks
@@ -165,15 +172,47 @@ Write-Host "============================================" -ForegroundColor Cyan
 if ($found) {
     Write-Host "  !! POTENTIAL COMPROMISE DETECTED" -ForegroundColor Red
     Write-Host ""
-    Write-Host "  1. Pin axios to 1.14.0: npm install axios@1.14.0 --save-exact"
-    Write-Host "  2. Remove node_modules and reinstall: rm -r node_modules; npm ci"
+    Write-Host "  1. Pin axios to 1.14.0 or 0.30.3"
+    Write-Host "  2. Remove node_modules and reinstall cleanly:"
+    switch ($pkgManager) {
+        "yarn" { Write-Host "       Remove-Item -Recurse node_modules; yarn install --frozen-lockfile" }
+        "pnpm" { Write-Host "       Remove-Item -Recurse node_modules; pnpm install --frozen-lockfile" }
+        "bun"  { Write-Host "       Remove-Item -Recurse node_modules; bun install --frozen-lockfile" }
+        "deno" { Write-Host "       deno install" }
+        default { Write-Host "       Remove-Item -Recurse node_modules; npm ci" }
+    }
     Write-Host "  3. Rotate ALL credentials"
     Write-Host "  4. Block sfrclak.com and 142.11.206.73"
     Write-Host "  5. If RAT found: FULL SYSTEM REBUILD"
 } else {
     Write-Host "  ALL CLEAR" -ForegroundColor Green
     Write-Host ""
-    Write-Host "  Preventive: npm install axios@1.14.0 --save-exact"
-    Write-Host "  Set: npm config set min-release-age 3"
+    Write-Host "  Preventive steps:"
+    Write-Host "  - Pin axios to a safe version:"
+    switch ($pkgManager) {
+        "yarn" {
+            Write-Host "       yarn add axios@1.14.0 --exact"
+            Write-Host "  - Use frozen installs in CI/CD: yarn install --frozen-lockfile"
+            Write-Host "  - Set ignore-scripts: true in .yarnrc.yml"
+        }
+        "pnpm" {
+            Write-Host "       pnpm add axios@1.14.0 --save-exact"
+            Write-Host "  - Use frozen installs in CI/CD: pnpm install --frozen-lockfile"
+            Write-Host "  - Set ignore-scripts=true in .npmrc"
+        }
+        "bun" {
+            Write-Host "       bun add axios@1.14.0 --exact"
+            Write-Host "  - Use frozen installs in CI/CD: bun install --frozen-lockfile"
+        }
+        "deno" {
+            Write-Host "       deno add npm:axios@1.14.0"
+        }
+        default {
+            Write-Host "       npm install axios@1.14.0 --save-exact"
+            Write-Host "  - Use frozen installs in CI/CD: npm ci"
+            Write-Host "  - Set ignore-scripts=true in .npmrc"
+            Write-Host "  - Run: npm config set min-release-age 3"
+        }
+    }
 }
 Write-Host "============================================" -ForegroundColor Cyan

--- a/check.ps1
+++ b/check.ps1
@@ -25,16 +25,38 @@ if ($axiosCheck) {
 # --- Check 2: Lockfile ---
 Write-Host ""
 Write-Host "[2/5] Checking lockfile..." -ForegroundColor Yellow
-if (Test-Path "package-lock.json") {
-    $lockHit = Select-String -Path "package-lock.json" -Pattern "1\.14\.1|0\.30\.4|plain-crypto-js"
-    if ($lockHit) {
-        Write-Host "  !! AFFECTED: Compromised reference in lockfile" -ForegroundColor Red
-        $found = $true
-    } else {
-        Write-Host "  OK: Lockfile clean" -ForegroundColor Green
+$lockfiles = @("package-lock.json", "yarn.lock", "pnpm-lock.yaml", "deno.lock")
+$lockfileFound = $false
+foreach ($lf in $lockfiles) {
+    if (Test-Path $lf) {
+        $lockfileFound = $true
+        $lockHit = Select-String -Path $lf -Pattern "1\.14\.1|0\.30\.4|plain-crypto-js"
+        if ($lockHit) {
+            Write-Host "  !! AFFECTED: Compromised reference in $lf" -ForegroundColor Red
+            $found = $true
+        } else {
+            Write-Host "  OK: $lf clean" -ForegroundColor Green
+        }
     }
-} else {
-    Write-Host "  SKIP: No package-lock.json found"
+}
+if (Test-Path "bun.lockb") {
+    $lockfileFound = $true
+    $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+    if ($bunCmd) {
+        $bunText = & bun bun.lockb 2>$null
+        $lockHit = $bunText | Select-String "1\.14\.1|0\.30\.4|plain-crypto-js"
+        if ($lockHit) {
+            Write-Host "  !! AFFECTED: Compromised reference in bun.lockb" -ForegroundColor Red
+            $found = $true
+        } else {
+            Write-Host "  OK: bun.lockb clean" -ForegroundColor Green
+        }
+    } else {
+        Write-Host "  WARN: bun.lockb found but 'bun' not installed — cannot decode binary lockfile, skipping" -ForegroundColor Yellow
+    }
+}
+if (-not $lockfileFound) {
+    Write-Host "  SKIP: No lockfile found"
 }
 
 # --- Check 3: Malicious dependency ---

--- a/check.ps1
+++ b/check.ps1
@@ -25,28 +25,80 @@ if ($axiosCheck) {
 # --- Check 2: Lockfile ---
 Write-Host ""
 Write-Host "[2/5] Checking lockfile..." -ForegroundColor Yellow
-$lockfiles = @("package-lock.json", "yarn.lock", "pnpm-lock.yaml", "deno.lock")
 $lockfileFound = $false
-foreach ($lf in $lockfiles) {
-    if (Test-Path $lf) {
-        $lockfileFound = $true
-        $lockHit = Select-String -Path $lf -Pattern "1\.14\.1|0\.30\.4|plain-crypto-js"
-        if ($lockHit) {
-            Write-Host "  !! AFFECTED: Compromised reference in $lf" -ForegroundColor Red
-            $found = $true
-        } else {
-            Write-Host "  OK: $lf clean" -ForegroundColor Green
-        }
+
+# Helper: find compromised axios version in decoded yarn-style text
+function Find-AxiosInYarnFormat($lines) {
+    $inAxios = $false
+    foreach ($line in $lines) {
+        if ($line -match '^axios@') { $inAxios = $true; continue }
+        if ($line -match '^[^ \t]') { $inAxios = $false }
+        if ($inAxios -and $line -match 'version "(1\.14\.1|0\.30\.4)"') { return $line }
+    }
+    return $null
+}
+
+if (Test-Path "package-lock.json") {
+    $lockfileFound = $true
+    # Scope to the axios entry specifically, not any package with that version number
+    $content = Get-Content "package-lock.json"
+    $axiosIdx = ($content | Select-String -Pattern '"node_modules/axios"').LineNumber
+    if ($axiosIdx) {
+        $block = $content[($axiosIdx)..([math]::Min($axiosIdx+3, $content.Count-1))]
+        $lockHit = $block | Select-String -Pattern '"(1\.14\.1|0\.30\.4)"'
+    }
+    if ($lockHit) {
+        Write-Host "  !! AFFECTED: Compromised axios version found in package-lock.json" -ForegroundColor Red
+        $found = $true
+    } else {
+        Write-Host "  OK: package-lock.json clean" -ForegroundColor Green
     }
 }
+
+if (Test-Path "yarn.lock") {
+    $lockfileFound = $true
+    $lockHit = Find-AxiosInYarnFormat (Get-Content "yarn.lock")
+    if ($lockHit) {
+        Write-Host "  !! AFFECTED: Compromised axios version found in yarn.lock" -ForegroundColor Red
+        $found = $true
+    } else {
+        Write-Host "  OK: yarn.lock clean" -ForegroundColor Green
+    }
+}
+
+if (Test-Path "pnpm-lock.yaml") {
+    $lockfileFound = $true
+    # pnpm entries are keyed as "/axios@VERSION:" or "axios@VERSION:"
+    $lockHit = Select-String -Path "pnpm-lock.yaml" -Pattern "(^|/)axios@(1\.14\.1|0\.30\.4):"
+    if ($lockHit) {
+        Write-Host "  !! AFFECTED: Compromised axios version found in pnpm-lock.yaml" -ForegroundColor Red
+        $found = $true
+    } else {
+        Write-Host "  OK: pnpm-lock.yaml clean" -ForegroundColor Green
+    }
+}
+
+if (Test-Path "deno.lock") {
+    $lockfileFound = $true
+    # deno.lock is JSON; npm entries are keyed as "axios@VERSION"
+    $lockHit = Select-String -Path "deno.lock" -Pattern '"axios@(1\.14\.1|0\.30\.4)"'
+    if ($lockHit) {
+        Write-Host "  !! AFFECTED: Compromised axios version found in deno.lock" -ForegroundColor Red
+        $found = $true
+    } else {
+        Write-Host "  OK: deno.lock clean" -ForegroundColor Green
+    }
+}
+
 if (Test-Path "bun.lockb") {
     $lockfileFound = $true
     $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
     if ($bunCmd) {
-        $bunText = & bun bun.lockb 2>$null
-        $lockHit = $bunText | Select-String "1\.14\.1|0\.30\.4|plain-crypto-js"
+        # bun.lockb is binary — decode to yarn-style text first, then scope to axios blocks
+        $bunLines = & bun bun.lockb 2>$null
+        $lockHit = Find-AxiosInYarnFormat $bunLines
         if ($lockHit) {
-            Write-Host "  !! AFFECTED: Compromised reference in bun.lockb" -ForegroundColor Red
+            Write-Host "  !! AFFECTED: Compromised axios version found in bun.lockb" -ForegroundColor Red
             $found = $true
         } else {
             Write-Host "  OK: bun.lockb clean" -ForegroundColor Green
@@ -55,6 +107,7 @@ if (Test-Path "bun.lockb") {
         Write-Host "  WARN: bun.lockb found but 'bun' not installed — cannot decode binary lockfile, skipping" -ForegroundColor Yellow
     }
 }
+
 if (-not $lockfileFound) {
     Write-Host "  SKIP: No lockfile found"
 }

--- a/check.sh
+++ b/check.sh
@@ -33,25 +33,71 @@ fi
 echo ""
 echo "[2/6] Checking lockfile for compromised versions..."
 LOCKFILE_FOUND=0
-for LOCKFILE in package-lock.json yarn.lock pnpm-lock.yaml deno.lock; do
-  if [ -f "$LOCKFILE" ]; then
-    LOCKFILE_FOUND=1
-    LOCK_HIT=$(grep -E "1\.14\.1|0\.30\.4" "$LOCKFILE" | head -3)
-    if [ -n "$LOCK_HIT" ]; then
-      echo "  !! AFFECTED: Compromised version found in $LOCKFILE"
-      echo "  $LOCK_HIT"
-      FOUND=1
-    else
-      echo "  OK: $LOCKFILE clean"
-    fi
+
+# Helper: check decoded yarn-style content for axios specifically
+# Finds blocks whose header starts with "axios@" and checks the resolved version
+check_axios_yarn_format() {
+  awk '/^axios@/{p=1} p && /  version "(1\.14\.1|0\.30\.4)"/{print; p=0} /^[^ \t]/{p=0}' "$1"
+}
+
+if [ -f "package-lock.json" ]; then
+  LOCKFILE_FOUND=1
+  # Scope to the axios entry in node_modules, not any package with that version number
+  LOCK_HIT=$(grep -A 3 '"node_modules/axios"' package-lock.json | grep -E '"(1\.14\.1|0\.30\.4)"' | head -3)
+  if [ -n "$LOCK_HIT" ]; then
+    echo "  !! AFFECTED: Compromised axios version found in package-lock.json"
+    echo "  $LOCK_HIT"
+    FOUND=1
+  else
+    echo "  OK: package-lock.json clean"
   fi
-done
+fi
+
+if [ -f "yarn.lock" ]; then
+  LOCKFILE_FOUND=1
+  LOCK_HIT=$(check_axios_yarn_format yarn.lock)
+  if [ -n "$LOCK_HIT" ]; then
+    echo "  !! AFFECTED: Compromised axios version found in yarn.lock"
+    echo "  $LOCK_HIT"
+    FOUND=1
+  else
+    echo "  OK: yarn.lock clean"
+  fi
+fi
+
+if [ -f "pnpm-lock.yaml" ]; then
+  LOCKFILE_FOUND=1
+  # pnpm entries are keyed as "/axios@VERSION:" or "axios@VERSION:"
+  LOCK_HIT=$(grep -E "(^|/)(axios)@(1\.14\.1|0\.30\.4):" pnpm-lock.yaml | head -3)
+  if [ -n "$LOCK_HIT" ]; then
+    echo "  !! AFFECTED: Compromised axios version found in pnpm-lock.yaml"
+    echo "  $LOCK_HIT"
+    FOUND=1
+  else
+    echo "  OK: pnpm-lock.yaml clean"
+  fi
+fi
+
+if [ -f "deno.lock" ]; then
+  LOCKFILE_FOUND=1
+  # deno.lock is JSON; npm entries are keyed as "axios@VERSION"
+  LOCK_HIT=$(grep -E '"axios@(1\.14\.1|0\.30\.4)"' deno.lock | head -3)
+  if [ -n "$LOCK_HIT" ]; then
+    echo "  !! AFFECTED: Compromised axios version found in deno.lock"
+    echo "  $LOCK_HIT"
+    FOUND=1
+  else
+    echo "  OK: deno.lock clean"
+  fi
+fi
+
 if [ -f "bun.lockb" ]; then
   LOCKFILE_FOUND=1
   if command -v bun &> /dev/null; then
-    LOCK_HIT=$(bun bun.lockb 2>/dev/null | grep -E "1\.14\.1|0\.30\.4" | head -3)
+    # bun.lockb is binary — decode to yarn-style text first, then scope to axios blocks
+    LOCK_HIT=$(bun bun.lockb 2>/dev/null | check_axios_yarn_format /dev/stdin)
     if [ -n "$LOCK_HIT" ]; then
-      echo "  !! AFFECTED: Compromised version found in bun.lockb"
+      echo "  !! AFFECTED: Compromised axios version found in bun.lockb"
       echo "  $LOCK_HIT"
       FOUND=1
     else
@@ -61,6 +107,7 @@ if [ -f "bun.lockb" ]; then
     echo "  WARN: bun.lockb found but 'bun' not installed — cannot decode binary lockfile, skipping"
   fi
 fi
+
 if [ $LOCKFILE_FOUND -eq 0 ]; then
   echo "  SKIP: No lockfile found in current directory"
 fi

--- a/check.sh
+++ b/check.sh
@@ -32,24 +32,36 @@ fi
 # --- Check 2: Lockfile contains compromised version ---
 echo ""
 echo "[2/6] Checking lockfile for compromised versions..."
-if [ -f "package-lock.json" ]; then
-  LOCK_HIT=$(grep -E "1\.14\.1|0\.30\.4" package-lock.json | head -3)
-  if [ -n "$LOCK_HIT" ]; then
-    echo "  !! AFFECTED: Compromised version found in package-lock.json"
-    echo "  $LOCK_HIT"
-    FOUND=1
-  else
-    echo "  OK: Lockfile clean"
+LOCKFILE_FOUND=0
+for LOCKFILE in package-lock.json yarn.lock pnpm-lock.yaml deno.lock; do
+  if [ -f "$LOCKFILE" ]; then
+    LOCKFILE_FOUND=1
+    LOCK_HIT=$(grep -E "1\.14\.1|0\.30\.4" "$LOCKFILE" | head -3)
+    if [ -n "$LOCK_HIT" ]; then
+      echo "  !! AFFECTED: Compromised version found in $LOCKFILE"
+      echo "  $LOCK_HIT"
+      FOUND=1
+    else
+      echo "  OK: $LOCKFILE clean"
+    fi
   fi
-elif [ -f "yarn.lock" ]; then
-  LOCK_HIT=$(grep -E "1\.14\.1|0\.30\.4" yarn.lock | head -3)
-  if [ -n "$LOCK_HIT" ]; then
-    echo "  !! AFFECTED: Compromised version found in yarn.lock"
-    FOUND=1
+done
+if [ -f "bun.lockb" ]; then
+  LOCKFILE_FOUND=1
+  if command -v bun &> /dev/null; then
+    LOCK_HIT=$(bun bun.lockb 2>/dev/null | grep -E "1\.14\.1|0\.30\.4" | head -3)
+    if [ -n "$LOCK_HIT" ]; then
+      echo "  !! AFFECTED: Compromised version found in bun.lockb"
+      echo "  $LOCK_HIT"
+      FOUND=1
+    else
+      echo "  OK: bun.lockb clean"
+    fi
   else
-    echo "  OK: Lockfile clean"
+    echo "  WARN: bun.lockb found but 'bun' not installed — cannot decode binary lockfile, skipping"
   fi
-else
+fi
+if [ $LOCKFILE_FOUND -eq 0 ]; then
   echo "  SKIP: No lockfile found in current directory"
 fi
 
@@ -57,7 +69,7 @@ fi
 echo ""
 echo "[3/6] Checking lockfile git history (forensic source of truth)..."
 if [ -d ".git" ]; then
-  GIT_HIT=$(git log -p -- package-lock.json yarn.lock 2>/dev/null | grep -E "plain-crypto-js" | head -3)
+  GIT_HIT=$(git log -p -- package-lock.json yarn.lock bun.lockb pnpm-lock.yaml deno.lock 2>/dev/null | grep -E "plain-crypto-js" | head -3)
   if [ -n "$GIT_HIT" ]; then
     echo "  !! WARNING: plain-crypto-js appeared in lockfile history"
     echo "  $GIT_HIT"

--- a/check.sh
+++ b/check.sh
@@ -33,6 +33,7 @@ fi
 echo ""
 echo "[2/6] Checking lockfile for compromised versions..."
 LOCKFILE_FOUND=0
+PKG_MANAGER="npm"  # default; overridden below if another lockfile is found
 
 # Helper: check decoded yarn-style content for axios specifically
 # Finds blocks whose header starts with "axios@" and checks the resolved version
@@ -43,7 +44,7 @@ check_axios_yarn_format() {
 if [ -f "package-lock.json" ]; then
   LOCKFILE_FOUND=1
   # Scope to the axios entry in node_modules, not any package with that version number
-  LOCK_HIT=$(grep -A 3 '"node_modules/axios"' package-lock.json | grep -E '"(1\.14\.1|0\.30\.4)"' | head -3)
+  LOCK_HIT=$(grep -A 5 '"node_modules/axios"' package-lock.json | grep -E '"(1\.14\.1|0\.30\.4)"' | head -3)
   if [ -n "$LOCK_HIT" ]; then
     echo "  !! AFFECTED: Compromised axios version found in package-lock.json"
     echo "  $LOCK_HIT"
@@ -55,6 +56,7 @@ fi
 
 if [ -f "yarn.lock" ]; then
   LOCKFILE_FOUND=1
+  PKG_MANAGER="yarn"
   LOCK_HIT=$(check_axios_yarn_format yarn.lock)
   if [ -n "$LOCK_HIT" ]; then
     echo "  !! AFFECTED: Compromised axios version found in yarn.lock"
@@ -67,6 +69,7 @@ fi
 
 if [ -f "pnpm-lock.yaml" ]; then
   LOCKFILE_FOUND=1
+  PKG_MANAGER="pnpm"
   # pnpm entries are keyed as "/axios@VERSION:" or "axios@VERSION:"
   LOCK_HIT=$(grep -E "(^|/)(axios)@(1\.14\.1|0\.30\.4):" pnpm-lock.yaml | head -3)
   if [ -n "$LOCK_HIT" ]; then
@@ -80,6 +83,7 @@ fi
 
 if [ -f "deno.lock" ]; then
   LOCKFILE_FOUND=1
+  PKG_MANAGER="deno"
   # deno.lock is JSON; npm entries are keyed as "axios@VERSION"
   LOCK_HIT=$(grep -E '"axios@(1\.14\.1|0\.30\.4)"' deno.lock | head -3)
   if [ -n "$LOCK_HIT" ]; then
@@ -93,6 +97,7 @@ fi
 
 if [ -f "bun.lockb" ]; then
   LOCKFILE_FOUND=1
+  PKG_MANAGER="bun"
   if command -v bun &> /dev/null; then
     # bun.lockb is binary — decode to yarn-style text first, then scope to axios blocks
     LOCK_HIT=$(bun bun.lockb 2>/dev/null | check_axios_yarn_format /dev/stdin)
@@ -191,7 +196,14 @@ if [ $FOUND -eq 1 ]; then
   echo ""
   echo "  Immediate actions:"
   echo "  1. Pin axios to 1.14.0 or 0.30.3"
-  echo "  2. rm -rf node_modules && npm ci"
+  echo "  2. Remove node_modules and reinstall cleanly:"
+  case "$PKG_MANAGER" in
+    yarn) echo "       yarn install --frozen-lockfile" ;;
+    pnpm) echo "       pnpm install --frozen-lockfile" ;;
+    bun)  echo "       bun install --frozen-lockfile" ;;
+    deno) echo "       deno install" ;;
+    *)    echo "       rm -rf node_modules && npm ci" ;;
+  esac
   echo "  3. Rotate ALL credentials (npm tokens, AWS, SSH, API keys)"
   echo "  4. Block sfrclak.com and 142.11.206.73 at firewall"
   echo "  5. If RAT artifacts found: FULL SYSTEM REBUILD"
@@ -201,9 +213,21 @@ else
   echo "  ALL CLEAR — No indicators of compromise found"
   echo ""
   echo "  Preventive steps:"
-  echo "  - Pin axios: npm install axios@1.14.0 --save-exact"
-  echo "  - Use npm ci (not npm install) in CI/CD"
-  echo "  - Set ignore-scripts=true in .npmrc"
-  echo "  - Run: npm config set min-release-age 3"
+  echo "  - Pin axios to a safe version:"
+  case "$PKG_MANAGER" in
+    yarn) echo "       yarn add axios@1.14.0 --exact"
+          echo "  - Use frozen installs in CI/CD: yarn install --frozen-lockfile"
+          echo "  - Set ignore-scripts: true in .yarnrc.yml" ;;
+    pnpm) echo "       pnpm add axios@1.14.0 --save-exact"
+          echo "  - Use frozen installs in CI/CD: pnpm install --frozen-lockfile"
+          echo "  - Set ignore-scripts=true in .npmrc" ;;
+    bun)  echo "       bun add axios@1.14.0 --exact"
+          echo "  - Use frozen installs in CI/CD: bun install --frozen-lockfile" ;;
+    deno) echo "       deno add npm:axios@1.14.0" ;;
+    *)    echo "       npm install axios@1.14.0 --save-exact"
+          echo "  - Use frozen installs in CI/CD: npm ci"
+          echo "  - Set ignore-scripts=true in .npmrc"
+          echo "  - Run: npm config set min-release-age 3" ;;
+  esac
 fi
 echo "============================================"


### PR DESCRIPTION
# Summary
- Extends lockfile scanning to cover yarn.lock, pnpm-lock.yaml, and deno.lock in addition to package-lock.json

- Adds correct handling for bun.lockb, which is a binary file and cannot be grepped directly

## Why additional lockfile checks?
The previous script only checked `package-lock.json` (npm) on Windows, and fell through to `yarn.lock `only as an elif on Linux/macOS - meaning projects using `pnpm` or `Deno`would get a false "SKIP: No lockfile found" result even if a lockfile existed. Developers who install the compromised axios version via any package manager are equally at risk, so all common lockfile formats should be scanned.

## Why bun.lockb needs special handling
`bun.lockb` uses a binary serialization format (JavaScriptCore's binary AST). Running grep against it directly is unreliable - version strings like 1.14.1 may not appear as plain ASCII in the binary encoding, meaning a compromised version could be present and go undetected. (This happened to me)

The fix decodes the lockfile first using bun `bun.lockb`, which outputs a human-readable yarn/npm-style text representation, and then greps that output. If bun is not installed, the script now emits an explicit warning rather than silently skipping preventing a false negative.