### PR TITLE
Fix URL lowercase casing for raw GitHub script links to theNetworkChuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ npm list -g axios
 
 **Mac/Linux:**
 ```bash
-curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash
+curl -sL https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex
+irm https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.ps1 | iex
 ```
 
 Or clone and run locally:
 ```bash
-git clone https://github.com/networkchuck/axios-attack-guide.git
+git clone https://github.com/theNetworkChuck/axios-attack-guide.git
 cd axios-attack-guide
 ./check.sh        # Mac/Linux
 .\check.ps1       # Windows PowerShell


### PR DESCRIPTION
## Fix: Raw GitHub URL casing for detection scripts

### What this fixes
The `irm | iex` command in the Windows detection section returns a `404 Not Found` error because the raw GitHub URL uses lowercase `networkchuck` instead of the correct `theNetworkChuck`.

GitHub raw content URLs are **case-sensitive**, so even a single character difference causes the request to fail — which means users running the detection script on a potentially compromised machine get no output at all.RLs in the README for accuracy.