### PR TITLE
Fix incorrect GitHub username in README URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ npm list -g axios
 
 **Mac/Linux:**
 ```bash
-curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash
+curl -sL https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex
+irm https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.ps1 | iex
 ```
 
 Or clone and run locally:
 ```bash
-git clone https://github.com/networkchuck/axios-attack-guide.git
+git clone https://github.com/theNetworkChuck/axios-attack-guide.git
 cd axios-attack-guide
 ./check.sh        # Mac/Linux
 .\check.ps1       # Windows PowerShell


### PR DESCRIPTION
## Summary

- Fixed 3 URLs in README.md that used `networkchuck` instead of `theNetworkChuck`, causing 404 errors
- Affected URLs: `check.sh` curl command, `check.ps1` PowerShell command, and `git clone` command

The raw.githubusercontent.com and github.com URLs pointed to a non-existent user, so the detection scripts couldn't be downloaded directly from the README instructions.