### PR TITLE
fix: README instructions reference and invalid repo. The name is theNetworkChuck instead of networkchuch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ npm list -g axios
 
 **Mac/Linux:**
 ```bash
-curl -sL https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.sh | bash
+curl -sL https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/networkchuck/axios-attack-guide/main/check.ps1 | iex
+irm https://raw.githubusercontent.com/theNetworkChuck/axios-attack-guide/main/check.ps1 | iex
 ```
 
 Or clone and run locally:
 ```bash
-git clone https://github.com/networkchuck/axios-attack-guide.git
+git clone https://github.com/theNetworkChuck/axios-attack-guide.git
 cd axios-attack-guide
 ./check.sh        # Mac/Linux
 .\check.ps1       # Windows PowerShell


### PR DESCRIPTION
As it is, the instructions in the README.md cannot be used but simply copying and pasting, as the github repository URL is outdated. This PR updates that URL, from `.../networkchuck/...` to `.../theNetworkChuck/...`